### PR TITLE
add service.labels and fix ingress service reference

### DIFF
--- a/couchdb/Chart.yaml
+++ b/couchdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: couchdb
-version: 3.6.3
+version: 3.6.4
 appVersion: 3.2.1
 description: A database featuring seamless multi-master sync, that scales from
   big data to mobile, with an intuitive HTTP/JSON API and designed for

--- a/couchdb/NEWS.md
+++ b/couchdb/NEWS.md
@@ -1,5 +1,17 @@
 # NEWS
 
+# 3.6.4
+
+- Add `service.labels` value to pass along labels to the client-facing service
+- Update `ingress` to use the service created by `service.enabled=true`,
+  instead of the headless service
+  ([#94](https://github.com/apache/couchdb-helm/issues/94))
+  - This allows setting `service.annotations`, `service.labels`, etc. in a way that will be picked up by the ingress
+
+# 3.6.3
+
+- Add PersistentVolume annotations
+
 ## 3.6.2
 
 - Change the `erlangCookie` to be auto-generated in a stateful fashion (i.e. we auto-generate it once, then leave that

--- a/couchdb/README.md
+++ b/couchdb/README.md
@@ -1,6 +1,6 @@
 # CouchDB
 
-![Version: 3.6.1](https://img.shields.io/badge/Version-3.6.1-informational?style=flat-square) ![AppVersion: 3.2.1](https://img.shields.io/badge/AppVersion-3.2.1-informational?style=flat-square)
+![Version: 3.6.4](https://img.shields.io/badge/Version-3.6.4-informational?style=flat-square) ![AppVersion: 3.2.1](https://img.shields.io/badge/AppVersion-3.2.1-informational?style=flat-square)
 
 Apache CouchDB is a database featuring seamless multi-master sync, that scales
 from big data to mobile, with an intuitive HTTP/JSON API and designed for
@@ -18,7 +18,7 @@ storage volumes to each Pod in the Deployment.
 ```bash
 $ helm repo add couchdb https://apache.github.io/couchdb-helm
 $ helm install couchdb/couchdb \
-  --version=3.6.1 \
+  --version=3.6.4 \
   --set allowAdminParty=true \
   --set couchdbConfig.couchdb.uuid=$(curl https://www.uuidgenerator.net/api/version4 2>/dev/null | tr -d -)
 ```
@@ -44,7 +44,7 @@ Afterwards install the chart replacing the UUID
 ```bash
 $ helm install \
   --name my-release \
-  --version=3.6.1 \
+  --version=3.6.4 \
   --set couchdbConfig.couchdb.uuid=decafbaddecafbaddecafbaddecafbad \
   couchdb/couchdb
 ```
@@ -85,7 +85,7 @@ and then install the chart while overriding the `createAdminSecret` setting:
 ```bash
 $ helm install \
   --name my-release \
-  --version=3.6.1 \
+  --version=3.6.4 \
   --set createAdminSecret=false \
   --set couchdbConfig.couchdb.uuid=decafbaddecafbaddecafbaddecafbad \
   couchdb/couchdb
@@ -121,7 +121,7 @@ upgrade as follows:
 
 ```bash
 $ helm upgrade <release-name> \
-  --version=3.6.1 \
+  --version=3.6.4 \
   --reuse-values \
   --set couchdbConfig.couchdb.uuid=<UUID> \
   couchdb/couchdb
@@ -134,7 +134,7 @@ version semantics. You can upgrade directly from `stable/couchdb` to this chart 
 
 ```bash
 $ helm repo add couchdb https://apache.github.io/couchdb-helm
-$ helm upgrade my-release --version=3.6.1 couchdb/couchdb
+$ helm upgrade my-release --version=3.6.4 couchdb/couchdb
 ```
 
 ## Configuration

--- a/couchdb/templates/ingress.yaml
+++ b/couchdb/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-{{- $serviceName := include "couchdb.fullname" . -}}
+{{- $serviceName := include "couchdb.svcname" . -}}
 {{- $servicePort := .Values.service.externalPort -}}
 {{- $path := .Values.ingress.path | quote -}}
 apiVersion: networking.k8s.io/v1

--- a/couchdb/templates/service.yaml
+++ b/couchdb/templates/service.yaml
@@ -8,10 +8,13 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-{{- if .Values.service.annotations }}
+    {{- with .Values.service.labels }}
+    {{- . | toYaml | nindent 4 }}
+    {{- end }}
+  {{- with .Values.service.annotations }}
   annotations:
-{{ toYaml .Values.service.annotations | indent 4 }}
-{{- end }}
+    {{- . | toYaml | nindent 4 }}
+  {{- end }}
 spec:
   ports:
     - port: {{ .Values.service.externalPort }}

--- a/couchdb/values.yaml
+++ b/couchdb/values.yaml
@@ -118,10 +118,11 @@ tolerations: []
 ## chart without any additional configuration. The Service block below refers
 ## to a second Service that governs how clients connect to the CouchDB cluster.
 service:
-  # annotations:
+  annotations: {}
   enabled: true
   type: ClusterIP
   externalPort: 5984
+  labels: {}
 
 ## An Ingress resource can provide name-based virtual hosting and TLS
 ## termination among other things for CouchDB deployments which are accessed


### PR DESCRIPTION
The ingress was mistakenly pointed to the headless service required for maintaining the statefulset. This means that `service.annotations`, etc. were not useful for controlling ingress behavior.

It might be desirable to change service names at some point to indicate which is headless / internal. However, that could be a disruptive action to any existing environments.

<!--
Thank you for contributing to couchdb-helm. Before you submit this PR we'd like to
make sure you are aware of the chart technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

Please make sure you test your changes before you push them.
-->

#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
- [x] Chart Version bumped
- [x] e2e tests pass
- [x] Variables are documented in the README.md
