### PR TITLE
chore: update chart-testing dependencies (#109)

### DIFF
--- a/test/e2e-kind.sh
+++ b/test/e2e-kind.sh
@@ -4,10 +4,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-readonly CT_VERSION=v3.5.0
-readonly KIND_VERSION=v0.11.1
+readonly CT_VERSION=v3.7.1
+readonly KIND_VERSION=v0.17.0
 readonly CLUSTER_NAME=chart-testing
-readonly K8S_VERSION=v1.19.7@sha256:a70639454e97a4b733f9d9b67e12c01f6b0297449d5b9cbbef87473458e26dca
+readonly K8S_VERSION=v1.25.3
 
 run_ct_container() {
     echo 'Running ct container...'

--- a/test/local-path-provisioner.yaml
+++ b/test/local-path-provisioner.yaml
@@ -42,7 +42,7 @@ subjects:
   name: local-path-provisioner-service-account
   namespace: local-path-storage
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: local-path-provisioner


### PR DESCRIPTION
* Update chart-testing to v3.7.1
 * Update kind to v0.17.0
 * Test against Kubernetes 1.25. The specific SHA is not specified to ensure image updates are picked up and the image for the appropriate cpu architecture are pulled.

This fixes issues running the tests on M1 macs.

<!--
Thank you for contributing to couchdb-helm. Before you submit this PR we'd like to
make sure you are aware of the chart technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

Please make sure you test your changes before you push them.
-->

#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
- [ ] Chart Version bumped
- [ ] e2e tests pass
- [ ] Variables are documented in the README.md
